### PR TITLE
Bump to v4.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 PROJECT = rabbitmq_rtopic_exchange
 PROJECT_DESCRIPTION = Reverse Topic Exchange Type
-PROJECT_VERSION=4.0.9
+PROJECT_VERSION=4.1.0
 
-RABBITMQ_VERSION ?= v4.0.9
+RABBITMQ_VERSION ?= 4.1.0
 current_rmq_ref = $(RABBITMQ_VERSION)
 
 define PROJECT_APP_EXTRA_KEYS
-	{broker_version_requirements, ["4.0.0"]}
+	{broker_version_requirements, ["4.1.0"]}
 endef
 
 dep_amqp_client                = git_rmq-subfolder rabbitmq-erlang-client $(RABBITMQ_VERSION)

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -40,8 +40,8 @@ endif
 # all projects use the same versions. It avoids conflicts.
 
 dep_accept = hex 0.3.5
-dep_cowboy = hex 2.12.0
-dep_cowlib = hex 2.13.0
+dep_cowboy = hex 2.13.0
+dep_cowlib = hex 2.14.0
 dep_credentials_obfuscation = hex 3.5.0
 dep_cuttlefish = hex 3.4.0
 dep_gen_batch_server = hex 0.8.8
@@ -51,10 +51,10 @@ dep_khepri_mnesia_migration = hex 0.7.2
 dep_meck = hex 1.0.0
 dep_osiris = git https://github.com/rabbitmq/osiris v1.8.7
 dep_prometheus = hex 4.11.0
-dep_ra = hex 2.15.3
-dep_ranch = hex 2.1.0
+dep_ra = hex 2.16.8
+dep_ranch = hex 2.2.0
 dep_recon = hex 2.5.6
-dep_redbug = hex 2.1.0
+dep_redbug = hex 2.0.7
 dep_systemd = hex 0.6.1
 dep_thoas = hex 1.2.1
 dep_observer_cli = hex 1.8.2


### PR DESCRIPTION
Bumping the project version, rabbit version and broker version requirements to 4.1.0. Also updating rabbitmq-components.mk to match same file in rmq 4.1.0